### PR TITLE
Fix directory selection

### DIFF
--- a/src/components/UI/FileSelect.vue
+++ b/src/components/UI/FileSelect.vue
@@ -21,25 +21,22 @@ export default {
     };
   },
   methods: {
-    handleInputClick() {
+    async handleInputClick() {
       if (!this.dialogOpen) {
         this.dialogOpen = true;
 
-        remote.dialog.showOpenDialog(
-          {
-            properties: ["openDirectory"],
-            createDirectory: this.createDirectory,
-            defaultPath: this.path || this.defaultPath,
-            openDirectory: true
-          },
-          paths => {
-            this.dialogOpen = false;
+        const result = await remote.dialog.showOpenDialog({
+          properties: ["openDirectory"],
+          createDirectory: this.createDirectory,
+          defaultPath: this.path || this.defaultPath,
+          openDirectory: true
+        });
 
-            if (paths && paths.length) {
-              this.$emit("update:path", paths[0]);
-            }
-          }
-        );
+        this.dialogOpen = false;
+
+        if (result.filePaths && result.filePaths.length) {
+          this.$emit("update:path", result.filePaths[0]);
+        }
       }
     }
   }


### PR DESCRIPTION
This fix selecting a directory which fix #506 and fix #507 

With electron 7 `dialog.showOpenDialog` doesn't take a callback anymore.
https://electronjs.org/docs/api/dialog#dialogshowopendialogbrowserwindow-options