### PR TITLE
Plater profile support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weakauras-companion",
-  "version": "3.0.0-beta1",
+  "version": "3.0.0-beta2",
   "description": "WeakAuras Companion App",
   "author": "Buds <mrbouyou@gmail.com>",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weakauras-companion",
-  "version": "3.0.0-beta2",
+  "version": "3.0.0-beta1",
   "description": "WeakAuras Companion App",
   "author": "Buds <mrbouyou@gmail.com>",
   "scripts": {

--- a/src/components/LandingPage.vue
+++ b/src/components/LandingPage.vue
@@ -1100,7 +1100,42 @@ export default Vue.extend({
       PlaterSavedData.body[0].init[0].fields.forEach((obj) => {
         if (obj.key.value === "profiles") {
           obj.value.fields.forEach((profile) => {
+            let profslug;
+            let profurl;
+            let profversion = 0;
+            let profsemver;
+            let profignoreWagoUpdate = false;
+            let profskipWagoUpdate = null;
+            let profid;
+
             profile.value.fields.forEach((profData) => {
+              if (profData.key.value === "Name") {
+                profid = profData.value.value;
+              }
+
+              if (profData.key.value === "version") {
+                profversion = Number(profData.value.value);
+              }
+
+              if (profData.key.value === "semver") {
+                profsemver = profData.value.value;
+              }
+
+              if (profData.key.value === "ignoreWagoUpdate") {
+                profignoreWagoUpdate = profData.value.value;
+              }
+
+              if (profData.key.value === "skipWagoUpdate") {
+                profskipWagoUpdate = profData.value.value;
+              }
+
+              if (profData.key.value === "url") {
+                profurl = profData.value.value;
+                const result = profurl.match(pattern);
+
+                if (result) ({ 2: profslug } = profurl.match(pattern));
+              }
+
               if (
                 profData.key.value === "script_data" ||
                 profData.key.value === "hook_data"
@@ -1172,6 +1207,33 @@ export default Vue.extend({
                 });
               }
             });
+
+            if (profslug) {
+              const foundAura = {
+                id: profid,
+                slug: profslug,
+                version: profversion,
+                semver: profsemver,
+                ignoreWagoUpdate: profignoreWagoUpdate,
+                skipWagoUpdate: profskipWagoUpdate,
+                wagoVersion: null,
+                wagoSemver: null,
+                changelog: null,
+                created: null,
+                modified: null,
+                author: null,
+                encoded: null,
+                wagoid: null,
+                ids: [profid],
+                topLevel: true,
+                uids: [],
+                regionType: null,
+                auraType: config.addonName,
+                addonConfig: config,
+              };
+
+              aurasFromFile.push(foundAura);
+            }
           });
         }
       });

--- a/src/components/LandingPage.vue
+++ b/src/components/LandingPage.vue
@@ -1070,6 +1070,7 @@ export default Vue.extend({
                 uids: uid ? [uid] : [],
                 regionType: null,
                 auraType: config.addonName,
+                auraTypeDisplay: config.addonName,
                 addonConfig: config,
               };
 
@@ -1199,6 +1200,7 @@ export default Vue.extend({
                       uids: [],
                       regionType: null,
                       auraType: config.addonName,
+                      auraTypeDisplay: config.addonName,
                       addonConfig: config,
                     };
 
@@ -1229,6 +1231,7 @@ export default Vue.extend({
                 uids: [],
                 regionType: null,
                 auraType: config.addonName,
+                auraTypeDisplay: config.addonName + "-Profile",
                 addonConfig: config,
               };
 
@@ -1331,6 +1334,7 @@ export default Vue.extend({
 
               //ensure config
               this.auras[index].auraType = foundAura.auraType;
+              this.auras[index].auraTypeDisplay = foundAura.auraTypeDisplay;
               this.auras[index].addonConfig = foundAura.addonConfig;
             }
           });

--- a/src/components/LandingPage.vue
+++ b/src/components/LandingPage.vue
@@ -1141,6 +1141,10 @@ export default Vue.extend({
                 profData.key.value === "script_data" ||
                 profData.key.value === "hook_data"
               ) {
+                let typeSuffix =
+                  (profData.key.value === "hook_data" && "-Mod") ||
+                  (profData.key.value === "script_data" && "-Script") ||
+                  "";
                 profData.value.fields.forEach((obj2) => {
                   let slug;
                   let url;
@@ -1200,7 +1204,7 @@ export default Vue.extend({
                       uids: [],
                       regionType: null,
                       auraType: config.addonName,
-                      auraTypeDisplay: config.addonName,
+                      auraTypeDisplay: config.addonName + typeSuffix,
                       addonConfig: config,
                     };
 

--- a/src/components/UI/Aura.vue
+++ b/src/components/UI/Aura.vue
@@ -39,7 +39,7 @@
     >
       {{ $t("app.aura.updateready" /* update ready */) }}
     </div>
-    <span class="tag">{{ aura.auraTypeDisplay }}</span>
+    <span class="tag">{{ aura.auraTypeDisplay || aura.auraType }}</span>
     <a
       v-tooltip="{
         content: wagoAuthorURL(aura.author),

--- a/src/components/UI/Aura.vue
+++ b/src/components/UI/Aura.vue
@@ -39,7 +39,7 @@
     >
       {{ $t("app.aura.updateready" /* update ready */) }}
     </div>
-    <span class="tag">{{ aura.auraType }}</span>
+    <span class="tag">{{ aura.auraTypeDisplay }}</span>
     <a
       v-tooltip="{
         content: wagoAuthorURL(aura.author),


### PR DESCRIPTION
- Adding support for Plater profiles in the Plater SavedVariables parser. Plater supports this in the latest alpha version.
- Adding a new "auraTypeDisplay" which is used as display tag in the aura list instead of just the addon name. This lets addons use multiple different tags without breaking addon configs.