### PR TITLE
change mac app to menu-app only

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -29,6 +29,9 @@ module.exports = {
         mac: {
           icon: "public/icon.icns",
           category: "Utility",
+          extendInfo: {
+            LSUIElement: 1,
+          },
         },
         win: {
           icon: "public/icon.ico",


### PR DESCRIPTION
currently, the dock icon does not provide any benefit, as clicking on it does nothing. The only way to show the app window is clicking on the menu bar icon. As such, the dock icon is a misleading piece of the UI, so this pull request removes it entirely -- shifting to a menu bar only experience.