### PR TITLE
explicitly set height and width to ensure correct window size

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -64,6 +64,8 @@ function handleLinks(link) {
 
 async function createWindow() {
   mainWindow = new BrowserWindow({
+    height: 550,
+    width: 940,
     minHeight: 550,
     minWidth: 940,
     frame: false,


### PR DESCRIPTION
Add settings to new BrowserWindow that explicitly set the height and width to the minHeight and minWidth. While this may seem redundant, it ensures that the window is correctly sized. Below is a screenshot of the current build (3.0.3) before proposed changes.

<img width="794" alt="Screen Shot 2020-07-29__Build v3 0 3" src="https://user-images.githubusercontent.com/26683765/88855218-21d4c000-d1b8-11ea-8ce1-25accbdbacef.png">
