### PR TITLE
adding additional UI enhancements to improve tray-only experience

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -174,7 +174,10 @@ async function createWindow() {
       },
     },
   ]);
-  tray.setContextMenu(contextMenu);
+  tray.on("right-click", () => tray.popUpContextMenu(contextMenu));
+
+  // Ignore double click events for the tray icon
+  tray.setIgnoreDoubleClickEvents(true);
 
   tray.on("click", () => {
     if (mainWindow.isVisible()) {


### PR DESCRIPTION
I love the fact that we have moved to a tray-only experience. However, there were a couple of UI aspects that I noticed that I think this PR helps to solve.

1. Not all left clicks were registering — sometimes I would click and nothing would happen, sometimes the context menu would show, sometimes the window would show
2. Left clicks both showed the window and the context menu, which was a bit confusing and led to a bit of a disjointed experience

To these ends, this PR does the following:

1. disables the double-click handler, ensuring that all left clicks register as clicks. Since we don’t have a handler for double-clicks, this just makes a better experience. 

1. Set context menu to be a right click action, more in line with other Mac apps. That way, the left click only shows and hides the window while the right click only shows the context menu.