### PR TITLE
Add deb and rpm build

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -45,27 +45,12 @@ jobs:
           CI: true
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
-      - name: Package Artifacts
-        run: |
-          mkdir artifact-appimage
-          mv dist_electron/*.AppImage artifact-appimage/ || true
-          mkdir artifact-snap
-          mv dist_electron/*.snap artifact-snap/ || true
-
       - uses: actions/upload-artifact@v2
-        name: Upload AppImage
+        name: Upload Artifacts
         with:
-          name: WeakAuras-Companion-CI-Node${{ matrix.node }} AppImage
-          path: artifact-appimage
-
-      - uses: actions/upload-artifact@v2
-        name: Upload Snap
-        with:
-          name: WeakAuras-Companion-CI-Node${{ matrix.node }} Snap
-          path: artifact-snap
-
-      - uses: actions/upload-artifact@v2
-        name: Upload Tarball
-        with:
-          name: WeakAuras-Companion-CI-Node${{ matrix.node }} Tarball
-          path: dist_electron/linux-unpacked
+          name: WeakAuras-Companion-CI
+          path: |
+            dist_electron/*.AppImage
+            dist_electron/*.snap
+            dist_electron/*.deb
+            dist_electron/*.rpm

--- a/.github/workflows/linux_pr.yml
+++ b/.github/workflows/linux_pr.yml
@@ -38,28 +38,13 @@ jobs:
         run: yarn dist:pr
         env:
           CI: true
-
-      - name: Package Artifacts
-        run: |
-          mkdir artifact-appimage
-          mv dist_electron/*.AppImage artifact-appimage/ || true
-          mkdir artifact-snap
-          mv dist_electron/*.snap artifact-snap/ || true
-
+          
       - uses: actions/upload-artifact@v2
-        name: Upload AppImage
+        name: Upload Artifacts
         with:
-          name: WeakAuras-Companion-PR-Node${{ matrix.node }} AppImage
-          path: artifact-appimage
-
-      - uses: actions/upload-artifact@v2
-        name: Upload Snap
-        with:
-          name: WeakAuras-Companion-PR-Node${{ matrix.node }} Snap
-          path: artifact-snap
-
-      - uses: actions/upload-artifact@v2
-        name: Upload Tarball
-        with:
-          name: WeakAuras-Companion-PR-Node${{ matrix.node }} Tarball
-          path: dist_electron/linux-unpacked
+          name: WeakAuras-Companion-PR
+          path: |
+            dist_electron/*.AppImage
+            dist_electron/*.snap
+            dist_electron/*.deb
+            dist_electron/*.rpm

--- a/vue.config.js
+++ b/vue.config.js
@@ -44,6 +44,7 @@ module.exports = {
           deleteAppDataOnUninstall: true,
         },
         linux: {
+          target: ["AppImage", "snap", "deb", "rpm"],
           icon: "public/bigicon.png",
           category: "Utility",
         },


### PR DESCRIPTION
This add deb and rpm to yarn build and modify GitHub workflow to upload artifacts with deb and rpm format.
This also remove Tarball as I think it's unnecessary, similar open source project don't upload this kind of artifact.
I didn't test if the assets are correctly uploaded when creating a new release.