### PR TITLE
feat: use `pinia` `vue` external

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,7 +38,8 @@
       "name": "Debug Renderer Process",
       "port": 9229,
       "request": "attach",
-      "type": "pwa-chrome"
+      "type": "pwa-chrome",
+      "timeout": 60000
     },
   ]
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,12 @@
   "engines": {
     "node": ">=16"
   },
+  "dependencies": {
+    "archiver": "^5.3.1",
+    "regedit": "^5.1.1",
+    "sharp": "^0.30.7",
+    "tga": "^1.0.7"
+  },
   "devDependencies": {
     "@electron/remote": "^2.0.8",
     "@intlify/vite-plugin-vue-i18n": "^6.0.1",
@@ -55,7 +61,6 @@
     "@vue/devtools": "^6.2.1",
     "@vue/eslint-config-standard": "^8.0.1",
     "@vue/eslint-config-typescript": "^11.0.0",
-    "archiver": "^5.3.1",
     "axios": "^0.27.2",
     "electron": "^20.0.2",
     "electron-builder": "^23.3.3",
@@ -78,14 +83,11 @@
     "pinia": "^2.0.18",
     "pinia-plugin-persistedstate-2": "^1.0.1",
     "prettier": "^2.7.1",
-    "regedit": "^5.1.1",
     "sass": "^1.54.4",
-    "sharp": "^0.30.7",
     "simple-git-hooks": "^2.8.0",
     "stylelint": "^14.10.0",
     "stylelint-config-recommended-scss": "^7.0.0",
     "tail": "^2.2.4",
-    "tga": "^1.0.7",
     "typescript": "^4.7.4",
     "vite": "^3.0.7",
     "vite-plugin-electron": "^0.9.0",

--- a/packages/renderer/index.html
+++ b/packages/renderer/index.html
@@ -7,6 +7,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <!-- <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline';" /> -->
   <title>WeakAuras Companion</title>
+  <script src="https://unpkg.com/vue@3.2.7/dist/vue.global.prod.js"></script>
+  <script src="https://unpkg.com/vue-demi@0.13.7/lib/index.iife.js"></script><!-- For pinia -->
+  <script src="https://unpkg.com/pinia@2.0.18/dist/pinia.iife.prod.js"></script>
 </head>
 
 <body>

--- a/packages/renderer/vite.config.ts
+++ b/packages/renderer/vite.config.ts
@@ -37,28 +37,10 @@ export default defineConfig({
       {
         // If you use the following modules, the following configuration will work
         // What they have in common is that they will return - ESM format code snippets
-
-        // ESM format string
-        // "electron-store": 'export default require("electron-store");',
-        // Use lib2esm() to easy to convert ESM
-        // Equivalent to
-        /**
-         * sqlite3: () => `
-         * const _M_ = require('sqlite3');
-         * const _D_ = _M_.default || _M_;
-         * export { _D_ as default }
-         * `
-         */
-        sqlite3: lib2esm("sqlite3", { format: "cjs" }),
-        serialport: lib2esm(
-          // CJS lib name
-          "serialport",
-          // export memebers
-          ["SerialPort", "SerialPortMock"],
-          { format: "cjs" }
-        ),
-        // C/C++ Native Addons
-        sharp: lib2esm("sharp", { format: "cjs" }),
+        sharp:    lib2esm("sharp",    Object.keys(require("sharp")),    { format: "cjs" }),
+        archiver: lib2esm("archiver", Object.keys(require("archiver")), { format: "cjs" }),
+        regedit:  lib2esm("regedit",  Object.keys(require("regedit")),  { format: "cjs" }),
+        tga:      lib2esm("tga",      Object.keys(require("tga")),      { format: "cjs" }),
       }
     ),
     eslintPlugin(),

--- a/packages/renderer/vite.config.ts
+++ b/packages/renderer/vite.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "vite";
 import renderer from "vite-plugin-electron-renderer";
 import eslintPlugin from "vite-plugin-eslint";
 import resolve, { lib2esm } from "vite-plugin-resolve";
+import { pinia, vue as vueExteral } from "vite-plugin-resolve/presets";
 import pkg from "../../package.json";
 import vueI18n from "@intlify/vite-plugin-vue-i18n";
 import { viteRequire } from "vite-require";
@@ -41,6 +42,9 @@ export default defineConfig({
         archiver: lib2esm("archiver", Object.keys(require("archiver")), { format: "cjs" }),
         regedit:  lib2esm("regedit",  Object.keys(require("regedit")),  { format: "cjs" }),
         tga:      lib2esm("tga",      Object.keys(require("tga")),      { format: "cjs" }),
+
+        pinia: pinia.v2,
+        vue: vueExteral.v3,
       }
     ),
     eslintPlugin(),


### PR DESCRIPTION
This PR for https://github.com/caoxiemeihao/vite-plugins/issues/36

1. External built-in [vite-plugin-resolve/presets](https://github.com/vite-plugin/vite-plugin-resolve#builtin-modules), and must be import CND in `index.html` (37d63d8)
2. At present, Vite's [Pre-Bundling](https://vitejs.dev/guide/dep-pre-bundling.html) can not bundle Node.js package correctly(I will consider submitting a PR or issue to Vite ), so we have configure them in `resolve()` (3dfcfbe), and move them to `dependenices`  (3011918)