### PR TITLE
enforce WeakAuras dependency

### DIFF
--- a/src/libs/write-addon-data.ts
+++ b/src/libs/write-addon-data.ts
@@ -173,6 +173,7 @@ export function writeAddonData(
 ## X-Category: Interface Enhancements
 ## DefaultState: Enabled
 ## LoadOnDemand: 0
+## Dependencies: WeakAuras
 ## OptionalDeps: ${addonDepts}
 
 data.lua


### PR DESCRIPTION
this is a "bug" I noticed while writing [Bisector](https://github.com/emptyrivers/wow-bisector) - WeakAuras calls EnableAddOn for the companion addon, but the companion addon doesn't list WeakAuras as a dependency.