### PR TITLE
Prevent Lua injection in generated addon data

### DIFF
--- a/src/libs/lua-string.spec.ts
+++ b/src/libs/lua-string.spec.ts
@@ -1,0 +1,42 @@
+import luaparse from "luaparse";
+import { describe, expect, it } from "vitest";
+
+import { serializeLuaString } from "./lua-string";
+
+function parseSerializedString(value: unknown): string {
+  const chunk = luaparse.parse(`return ${serializeLuaString(value)}`);
+  const statement = chunk.body[0];
+
+  if (
+    statement?.type !== "ReturnStatement" ||
+    statement.arguments[0]?.type !== "StringLiteral"
+  ) {
+    throw new Error("Expected a single Lua string literal");
+  }
+
+  return statement.arguments[0].value;
+}
+
+describe("serializeLuaString", () => {
+  it("preserves values containing Lua long-string delimiters", () => {
+    const maliciousValue = 'name]=]; error("injected") -- [==[still data]==]';
+
+    expect(parseSerializedString(maliciousValue)).toBe(maliciousValue);
+  });
+
+  it("prevents a closing delimiter from spanning the content boundary", () => {
+    const boundaryValue = "contains ]=] and ends with a wider prefix]==";
+
+    expect(parseSerializedString(boundaryValue)).toBe(boundaryValue);
+  });
+
+  it("preserves a leading newline", () => {
+    const multilineValue = "\nfirst line\nsecond line";
+
+    expect(parseSerializedString(multilineValue)).toBe(multilineValue);
+  });
+
+  it("serializes non-string values as strings", () => {
+    expect(parseSerializedString(42)).toBe("42");
+  });
+});

--- a/src/libs/lua-string.ts
+++ b/src/libs/lua-string.ts
@@ -1,0 +1,14 @@
+export function serializeLuaString(value: unknown): string {
+  const content = String(value);
+  let separator = "=";
+
+  while (
+    content.includes(`]${separator}]`) ||
+    content.endsWith(`]${separator}`)
+  ) {
+    separator += "=";
+  }
+
+  // Lua discards one newline immediately after a long-string opener.
+  return `[${separator}[\n${content}]${separator}]`;
+}

--- a/src/libs/write-addon-data.ts
+++ b/src/libs/write-addon-data.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { backup } from "@/libs/backup";
 import { grabVersionFromInstalledAddons } from "@/libs/grab-wa-version";
+import { serializeLuaString } from "@/libs/lua-string";
 import sanitize from "@/libs/sanitize";
 import { matchFolderNameInsensitive } from "@/libs/utilities";
 import type { StashStore } from "@/stores/auras";
@@ -65,14 +66,11 @@ export function writeAddonData(
       aurasWithData
         .filter((aura: AuraType) => aura.auraType === config.addonName)
         .forEach((aura: AuraType) => {
-          LuaSlugs += `${spacing}    ["${aura.slug.replace(
-            /"/g,
-            '\\"',
-          )}"] = {\n`;
+          LuaSlugs += `${spacing}    [${serializeLuaString(aura.slug)}] = {\n`;
 
           fields.forEach((field) => {
             if (aura[field]) {
-              LuaSlugs += `${spacing}      ${field} = [=[${aura[field]}]=],\n`;
+              LuaSlugs += `${spacing}      ${field} = ${serializeLuaString(aura[field])},\n`;
             }
           });
 
@@ -88,7 +86,7 @@ export function writeAddonData(
               sanitized = sanitize.markdown(aura.changelog.text);
             }
 
-            LuaSlugs += `${spacing}      versionNote = [=[${sanitized}]=],\n`;
+            LuaSlugs += `${spacing}      versionNote = ${serializeLuaString(sanitized)},\n`;
           }
 
           LuaSlugs += `${spacing}    },\n`;
@@ -100,14 +98,11 @@ export function writeAddonData(
       stash.auras
         .filter((aura) => aura.auraType === config.addonName)
         .forEach((aura) => {
-          LuaOutput += `${spacing}    ["${aura.slug.replace(
-            /"/g,
-            '\\"',
-          )}"] = {\n`;
+          LuaOutput += `${spacing}    [${serializeLuaString(aura.slug)}] = {\n`;
 
           fields.forEach((field) => {
             if (aura[field]) {
-              LuaOutput += `${spacing}      ${field} = [=[${aura[field]}]=],\n`;
+              LuaOutput += `${spacing}      ${field} = ${serializeLuaString(aura[field])},\n`;
             }
           });
 
@@ -123,10 +118,10 @@ export function writeAddonData(
               sanitized = sanitize.markdown(aura.changelog.text);
             }
 
-            LuaOutput += `${spacing}      versionNote = [=[${sanitized}]=],\n`;
+            LuaOutput += `${spacing}      versionNote = ${serializeLuaString(sanitized)},\n`;
           }
 
-          LuaOutput += `${spacing}      source = "${aura.source}",\n`;
+          LuaOutput += `${spacing}      source = ${serializeLuaString(aura.source)},\n`;
           LuaOutput += `${spacing}    },\n`;
         });
 
@@ -146,7 +141,7 @@ export function writeAddonData(
               title: v.match(regex)[1],
             }))
             .forEach((file) => {
-              LuaOutput += `${spacing}    [ [=[${file.filename}]=] ] = [=[${file.title}]=],\n`;
+              LuaOutput += `${spacing}    [${serializeLuaString(file.filename)}] = ${serializeLuaString(file.title)},\n`;
             });
         }
 


### PR DESCRIPTION
## Finding

The generated `data.lua` embedded Wago-controlled aura metadata, encoded payloads, changelogs, slugs, and local animation names with a fixed Lua long-string delimiter. A value containing that delimiter could terminate the literal and make the remainder executable when World of Warcraft loads the companion addon.

## Changes

- add a shared Lua long-string serializer that selects a delimiter absent from both the content and the content/closer boundary
- preserve leading newlines according to Lua long-string parsing rules
- route every dynamic Lua string in `write-addon-data.ts` through the serializer
- add parser-backed regression coverage for delimiter injection, boundary overlap, leading newlines, and non-string values

## Validation

Baseline before the change:
- `pnpm lint` — passed with 66 pre-existing UnoCSS ordering warnings
- `pnpm test` — 11 tests passed
- `pnpm exec vue-tsc --noEmit` — passed

After the change:
- `pnpm lint` — passed with the same 66 pre-existing warnings
- `pnpm test` — 15 tests passed
- `pnpm exec vue-tsc --noEmit` — passed
- `pnpm exec vite build` — renderer, main, and preload builds passed
- deterministic parser round-trip check — 21,845 delimiter/newline combinations passed
- `git diff --check` — passed

`pnpm build` was not run because packaging, Electron configuration, native dependencies, and release behavior were not changed.

## Adversarial review

The review initially found that a delimiter prefix at the end of content could overlap the generated closer. That Required finding was fixed with an additional boundary check and regression test. Re-review found no Critical or Required findings, no missed untrusted string interpolation sites, and approved the final diff. The reviewer also independently passed a 100,000-value Lua parser round-trip corpus.

## Deferred work

- pre-existing pnpm configuration, UnoCSS ordering, and Vite chunk-size warnings are unchanged and unrelated
- broader Electron renderer isolation and custom-control accessibility work require separate, focused changes; this PR makes no unrelated architectural or UI refactor